### PR TITLE
Revert changes in `resourceRulesDelete`

### DIFF
--- a/internal/cortex/resource_rules.go
+++ b/internal/cortex/resource_rules.go
@@ -85,6 +85,7 @@ func resourceRulesDelete(ctx context.Context, d *schema.ResourceData, m interfac
 		namespace = d.Get("namespace").(string)
 		groupName = strings.Split(d.Id(), "/")[0]
 		tenantID  string
+		diags     diag.Diagnostics
 	)
 
 	if data, ok := d.GetOk("tenant_id"); ok {
@@ -103,7 +104,7 @@ func resourceRulesDelete(ctx context.Context, d *schema.ResourceData, m interfac
 
 	d.SetId("")
 
-	return resourceRulesRead(ctx, d, m)
+	return diags
 }
 
 func resourceRulesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {


### PR DESCRIPTION
PR closes https://github.com/form3tech/tooling-team/issues/586

PR reverts changes introduced [here](https://github.com/form3tech-oss/terraform-provider-cortex/commit/9a17bc1878ca2d0d0444d770478f39186b6b108a#diff-a29447c036f5cea52ea5f2d3d39dd2682d625299a7d34de38dc67d2bd978af09R79) which caused [TFE run](https://terraform.management.form3.tech/app/infrastructure/workspaces/development-grafana-cloud/runs/run-fT2xc15F2Qb6hq1e) has failed