### PR TITLE
Add release for darwin arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ build:
 
 .PHONY: release
 release:
+	GOOS=darwin GOARCH=arm64 go build -o ./bin/${BINARY}_${VERSION}_darwin_arm64
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
 	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64


### PR DESCRIPTION
This PR adds a release for arm64 darwin architecture supporting running on Mac M1 machines.